### PR TITLE
Add ProtectedRoute component and useUserState hook

### DIFF
--- a/src/components/MainContainer.tsx
+++ b/src/components/MainContainer.tsx
@@ -4,6 +4,7 @@ import PeepsContainer from "./PeepsContainer";
 import SignUpForm from "./SignUpForm";
 import LoginForm from "./LoginForm";
 import { UserContextProvider } from "../contexts/UserContext";
+import ProtectedRoute from "./ProtectedRoute";
 
 const MainContainer: React.FC = () => {
   return (
@@ -13,12 +14,12 @@ const MainContainer: React.FC = () => {
           exact
           path="/"
           render={() => {
-            return <Redirect to="/signup" />;
+            return <Redirect to="/login" />;
           }}
         />
         <Route exact path="/signup" component={SignUpForm} />
-        <Route exact path="/peeps" component={PeepsContainer} />
         <Route exact path="/login" component={LoginForm} />
+        <ProtectedRoute exact path="/peeps" component={PeepsContainer} />
       </Switch>
     </UserContextProvider>
   );

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,17 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import * as React from "react";
+import { Redirect, Route, RouteProps } from "react-router-dom";
+import useUserState from "../hooks/useUserState";
+
+const ProtectedRoute: React.FC<RouteProps> = (props) => {
+  const { isLoggedIn } = useUserState();
+
+  if (isLoggedIn()) {
+    return <Route {...props} />;
+  } else {
+    const renderComponent = () => <Redirect to={{ pathname: "/login" }} />;
+    return <Route {...props} component={renderComponent} render={undefined} />;
+  }
+};
+
+export default ProtectedRoute;

--- a/src/hooks/useUserState.tsx
+++ b/src/hooks/useUserState.tsx
@@ -1,0 +1,16 @@
+import { useContext } from "react";
+import { UserContext } from "../contexts/UserContext";
+
+const useUserState: () => { isLoggedIn: () => boolean } = () => {
+  const [userState] = useContext(UserContext);
+
+  const isLoggedIn: () => boolean = () => {
+    return userState.name !== "";
+  };
+
+  return {
+    isLoggedIn
+  };
+};
+
+export default useUserState;

--- a/src/tests/MainContainer.test.tsx
+++ b/src/tests/MainContainer.test.tsx
@@ -12,16 +12,14 @@ describe("MainContainer", () => {
     mock.restore();
   });
 
-  it("renders signup form by by default", () => {
+  it("renders login form by by default", () => {
     render(
       <Router>
         <MainContainer />
       </Router>
     );
 
-    expect(
-      screen.getByRole("heading", { name: "Sign up" })
-    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Log in" })).toBeInTheDocument();
   });
 
   it("renders renders login when you successfully sign up", async () => {
@@ -30,7 +28,7 @@ describe("MainContainer", () => {
       .reply(200, { id: 1, username: "bob" });
 
     render(
-      <Router>
+      <Router initialEntries={["/signup"]} initialIndex={0}>
         <MainContainer />
       </Router>
     );
@@ -67,7 +65,7 @@ describe("MainContainer", () => {
     });
 
     render(
-      <Router>
+      <Router initialEntries={["/signup"]} initialIndex={0}>
         <MainContainer />
       </Router>
     );
@@ -96,5 +94,15 @@ describe("MainContainer", () => {
     fireEvent.click(screen.getByRole("button", { name: "Submit" }));
 
     expect(await screen.findByText("Peeps List")).toBeInTheDocument();
+  });
+
+  it("redirects to login if you try to get the peeps list without logging", () => {
+    render(
+      <Router initialEntries={["/peeps"]} initialIndex={0}>
+        <MainContainer />
+      </Router>
+    );
+
+    expect(screen.getByRole("heading", { name: "Log in" })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
The useUserState hook provides a convenience method to check if a
user is logged in.

ProtectedRoute is used to prevent the user accessing certain
routes unless they are logged in. At the moment the only route
that has been protected in this way is /peeps. In all cases, you
are redirected to the login route if you try to access a protected
route without logging in.